### PR TITLE
fix(ci): fix SUSFS build on older GKI versions and update cherry-pick commits

### DIFF
--- a/.github/actions/susfs-patches/action.yml
+++ b/.github/actions/susfs-patches/action.yml
@@ -154,3 +154,21 @@ runs:
       working-directory: ${{ github.workspace }}/kernel/common
       run: |
         patch -p1 < 50_add_susfs_in_gki-${{ inputs.version }}.patch
+
+        # SUSFS's OPEN_REDIRECT code unconditionally calls VMA_PAD_START(), which
+        # only exists on GKI branches that carry Google's page-size-migration
+        # feature (added to each android version's kernel/common branch at a
+        # different, sometime later, os_patch_level). Older os_patch_levels in
+        # our build matrix predate it, so fall back to a no-padding definition
+        # when the real header/macro isn't present. This is version-agnostic and
+        # a no-op wherever the real header already provides it.
+        if grep -q 'VMA_PAD_START(' fs/proc/task_mmu.c && ! grep -qE '#include <linux/pgsize_migration(_inline)?\.h>|define VMA_PAD_START' fs/proc/task_mmu.c; then
+          sed -i '1a #ifndef VMA_PAD_START\n#define VMA_PAD_START(vma) ((vma)->vm_end)\n#endif' fs/proc/task_mmu.c
+          echo "Added VMA_PAD_START fallback definition to fs/proc/task_mmu.c"
+        fi
+
+        # Same story for __fold_filemap_fixup_entry(), declared in page_size_compat.h.
+        if grep -q '__fold_filemap_fixup_entry' fs/proc/task_mmu.c && ! grep -q '#include <linux/page_size_compat.h>' fs/proc/task_mmu.c; then
+          sed -i '/#include <linux\/pkeys.h>/a #include <linux/page_size_compat.h>' fs/proc/task_mmu.c
+          echo "Added page_size_compat.h include to fs/proc/task_mmu.c"
+        fi

--- a/.github/actions/susfs-setup/action.yml
+++ b/.github/actions/susfs-setup/action.yml
@@ -32,8 +32,8 @@ runs:
 
         cd susfs4ksu
 
-        COMMIT1="8d2420be13e43d4cc0d80215d08ed475081a1404"
-        COMMIT2="ee71ca33d08710d686f2bdba27cacefe9e615fb9"
+        COMMIT1="e03f6b0773402aa2e121160745143d2539d4475c"
+        COMMIT2="342c7ea156190ff2cc905bb6bf18d3807af84014"
 
         git remote add pershoot https://gitlab.com/pershoot/susfs4ksu.git
         git fetch pershoot gki-android14-6.1-dev


### PR DESCRIPTION
This PR resolves build failures on older kernel patch levels in the build matrix and updates the cherry-pick commits from the `pershoot` repository.

### Key Changes:
* **Page-size migration workarounds (`susfs-patches`):**
  * Added a fallback definition for `VMA_PAD_START(vma)` (resolves to `(vma)->vm_end`) in `fs/proc/task_mmu.c` for GKI branches that predates Google's page-size migration feature.
  * Added conditional inclusion of `<linux/page_size_compat.h>` in `fs/proc/task_mmu.c` if `__fold_filemap_fixup_entry` is present but the header is not included.
* **SUSFS setup updates (`susfs-setup`):**
  * Updated target cherry-pick commits (`COMMIT1` and `COMMIT2`) from `pershoot/susfs4ksu.git` to their latest hashes.
